### PR TITLE
Ignore files on import

### DIFF
--- a/src/admin/md/usage.md
+++ b/src/admin/md/usage.md
@@ -31,6 +31,7 @@
 * **-s**, **-\-store** &mdash; Specify a datastore file (default: data.db)
 * **-\-system**  &mdash; Set the system flag for import, export, and delete operations
 * **-\-import-tags**  &mdash; During import read tags from '_tags' file and apply them to imported documents from the same directory.
+* **-\-not-searchable**  &mdash; During import exclude content of files and folders starting with '_' from full text search.
 * **-t**, **-\-type** &mdash; Specify a content type for the body an operation to be executed via the execute command.
 * **-u**, **-\-uri** &mdash; Specify an uri to execute an operation through the execute command.
 * **-v**, **-\-version** &mdash; Display the program version.
@@ -80,6 +81,8 @@ Import all documents stored in a directory called **system** as system documents
 
 [litestore import -d:system -\-system](class:cmd)
 
+#### Importing a directory and tagging files
+
 Import all documents stored in a directory called **media** (including subdirectories):
 
 ```
@@ -104,6 +107,38 @@ Import all documents stored in a directory called **media** (including subdirect
 Every **_tags** file contains a list of tags, one per line, which are applied to all imported documents from the same directory. In the example above all cars and planes images will be tagged on import. The trains images, not as there is not **_tags** file in the **trains** directory.
 
 The individual **_tags** files are also imported. When the **\-\-import\-tags** option is not set the **_tags** files are ignored and not imported.
+
+#### Excluding files from full text search
+
+Import all documents stored in a directory called **media** (including subdirectories):
+
+```
++ media
+  + _css
+  | + style1.css
+  | ` style2.css
+  + cars
+  | + _index.html
+  | + Lamborghini.md
+  | + VW.md
+  | ` BMW.md
+  + planes
+  | + _index.html
+  | + 767.md
+  | + F-16.md
+  | ` B-1.md
+  ` trains
+    + _index.html
+    * _script.js
+    + TGV.md
+    ` Eurostar.md
+```   
+
+[litestore import -d:media -\-not-searchable](class:cmd)
+
+All documents are imported but the files starting which name starts with **underscore** and files inside a folder which name starts with **underscore** are excluded from full text serach. The idea is that these files have special meaning for the application:
+* they should be accessible via regular URLs (unlike **system** files)
+* but they content should not be searchable.
 
 #### Exporting a directory
 

--- a/src/litestore.nim
+++ b/src/litestore.nim
@@ -107,7 +107,7 @@ when isMainModule:
         LS.serve
         runForever()
       of opImport:
-        LS.store.importDir(LS.directory, LS.manageSystemData, LS.importTags)
+        LS.store.importDir(LS.directory, LS.manageSystemData, LS.importTags, LS.notSerachable)
       of opExport:
         LS.store.exportDir(LS.directory, LS.manageSystemData)
       of opDelete:

--- a/src/litestorepkg/lib/cli.nim
+++ b/src/litestorepkg/lib/cli.nim
@@ -19,6 +19,7 @@ var
   logLevel = "warn"
   system = false
   importTags = false
+  notSerachable = false
   mount = false
   auth = newJNull()
   middleware = newStringTable()
@@ -63,7 +64,8 @@ let
     -r, --readonly      Allow only data retrieval operations.
     -s, --store         Specify a datastore file (default: data.db)
     --system            Set the system flag for import, export, and delete operations
-    --tags              During import read tags from '_tags' file and apply them to imported documents from the same directory.
+    --import-tags       During import read tags from '_tags' file and apply them to imported documents from the same directory.
+    --not-searchable    During import exclude content of files and folders starting with '_' from full text search.
     -t, --type          Specify a content type for the body an operation to be executed via the execute command.
     -u, --uri           Specify an uri to execute an operation through the execute command.
     -v, --version       Display the program version.
@@ -163,6 +165,9 @@ proc run*() =
           of "import-tags":
             importTags = true
             cliSettings["import-tags"] = %importTags
+          of "not-searchable":
+            notSerachable = true
+            cliSettings["not-searchable"] = %notSerachable
           of "version", "v":
             echo pkgVersion
             quit(0)
@@ -193,6 +198,7 @@ proc run*() =
   LS.config = configuration
   LS.configFile = configFile
   LS.importTags = importTags
+  LS.notSerachable = notSerachable
   LS.mount = mount
   LS.execution.file = exFile
   LS.execution.body = exBody

--- a/src/litestorepkg/lib/core.nim
+++ b/src/litestorepkg/lib/core.nim
@@ -1,13 +1,13 @@
 import
   x_sqlite3,
   x_db_sqlite as db,
-  strutils,
   os,
   oids,
   json,
   pegs,
   strtabs,
   strutils,
+  sequtils,
   base64,
   math
 import
@@ -590,10 +590,11 @@ proc importDir*(store: Datastore, dir: string, system = false, importTags = fals
   for f in dir.walkDirRec():
     if f.dirExists:
       continue
-    let fileName = f.splitFile.name
-    if fileName.startsWith("."):
-      # Ignore hidden files
-      continue
+    let dirs = f.split(DirSep)  
+    if dirs.any(proc (s: string): bool = return s.startsWith(".")):
+      # Ignore hidden directories and files
+      continue  
+    let fileName = f.splitFile.name    
     if fileName == "_tags" and not importTags:
       # Ignore tags file unless the CLI flag was set
       continue

--- a/src/litestorepkg/lib/types.nim
+++ b/src/litestorepkg/lib/types.nim
@@ -89,6 +89,7 @@ type
     manageSystemData*: bool
     file*: string
     importTags*: bool
+    notSerachable*: bool
     mount*: bool
     readonly*: bool
     appname*: string


### PR DESCRIPTION
Fabio,
There are 2 changesets in this PR:
- one is related to a new command line option for import operation which prevents files originating from folders starting with _ to be included in full text search. I keep some configuration files, templates, css or js in such folders and didn't want to see them as resutls of search operations.
- another one is extension of the existing feature which ignored files starting with dot. I had .git folder as part of my documents folder and I wanted to exclude it completely on import. I think this change is not intrusive and you might want to merge it in.
Cheers,
Piotr 